### PR TITLE
fix: code scanning alert no. 8: Code injection

### DIFF
--- a/.github/workflows/prow.yml
+++ b/.github/workflows/prow.yml
@@ -33,8 +33,10 @@ jobs:
           go mod tidy
 
       - name: Convert GitHub event to single-line JSON
+        env:
+          EVENT: ${{ toJson(github.event) }}
         run: |
-          echo "EVENT=$(echo '${{ toJson(github.event) }}' | jq -c '.')" >> $GITHUB_ENV
+          echo "EVENT=$(echo \"$EVENT\" | jq -c '.')" >> $GITHUB_ENV
 
       - name: Run Prow Lite
         run: |

--- a/.github/workflows/prow.yml
+++ b/.github/workflows/prow.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           EVENT: ${{ toJson(github.event) }}
         run: |
-          echo "EVENT=$(echo \"$EVENT\" | jq -c '.')" >> $GITHUB_ENV
+          echo "EVENT=$(jq -n --arg event \"$EVENT\" '$event | @json')" >> $GITHUB_ENV
 
       - name: Run Prow Lite
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/patrickblackjr/prow-lite/security/code-scanning/8](https://github.com/patrickblackjr/prow-lite/security/code-scanning/8)

To fix the code injection vulnerability, we should avoid directly interpolating user-controlled input into shell commands. Instead, set the value of `${{ toJson(github.event) }}` to an environment variable using the `env:` key in the step, and then reference it using shell-native syntax (`$EVENT`) in the script. This prevents the shell from interpreting any injected metacharacters. Specifically, in the "Convert GitHub event to single-line JSON" step, move the assignment of the event JSON to the `env:` block, and update the shell command to use `$EVENT` directly. No additional dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
